### PR TITLE
Deal with deployment based on ebignore

### DIFF
--- a/ebi/appversion.py
+++ b/ebi/appversion.py
@@ -26,14 +26,12 @@ def make_version_file(version_label, dockerrun=None, docker_compose=None, ebext=
 
     * Including :param dockerrun: file as Dockerrun.aws.json
     * Including :param docker-compose: file as dockerrun-compose.yml (for Amazon linux2)
-    * Including :param exext: directory as .ebextensions/
+    * Including :param ebext: directory as .ebextensions/
     * Including :param ebignore: file as .ebignore
 
     :return: File path to created zip file (current directory).
     """
     dockerrun = dockerrun or DOCKERRUN_NAME
-    # docker-compose takes precedence over dockerrun
-    docker_settings = docker_compose or dockerrun
 
     ebext = ebext or DOCKEREXT_NAME
 

--- a/ebi/commands/bgdeploy.py
+++ b/ebi/commands/bgdeploy.py
@@ -110,7 +110,7 @@ def main(parsed):
     ###
     if parsed.version:
         version = parsed.version
-    elif parsed.prefix :
+    elif parsed.prefix:
         version = "{}_{}".format(parsed.prefix, int(time.time()))
     else:
         version = str(int(time.time()))
@@ -120,7 +120,7 @@ def main(parsed):
     else:
         description = ''
 
-    appversion.make_application_version(parsed.app_name, version, parsed.dockerrun, parsed.docker_compose, parsed.ebext, description)
+    appversion.make_application_version(parsed.app_name, version, parsed.dockerrun, parsed.docker_compose, parsed.ebext, parsed.ebignore, description)
     logger.info('Ok, now deploying the version %s for %s', version, secondary_env_name)
     payload = ['eb', 'deploy', secondary_env_name,
                '--version=' + version]
@@ -193,6 +193,7 @@ def apply_args(parser):
     parser.add_argument('--dockerrun', help='Path to file used as Dockerrun.aws.json')
     parser.add_argument('--docker_compose', help='Path to file used as docker-compose.yml')
     parser.add_argument('--ebext', help='Path to directory used as .ebextensions/')
+    parser.add_argument('--ebignore', help='Path to enignore used as .ebignore')
     parser.add_argument('--capacity', help='Set the number of instances.',
                         action='store_true', default=False)
     parser.set_defaults(func=main)

--- a/ebi/commands/clonedeploy.py
+++ b/ebi/commands/clonedeploy.py
@@ -74,7 +74,7 @@ def main(parsed):
     ###
     if parsed.version:
         version = parsed.version
-    elif parsed.prefix :
+    elif parsed.prefix:
         version = "{}_{}".format(parsed.prefix, int(time.time()))
     else:
         version = str(int(time.time()))
@@ -84,7 +84,7 @@ def main(parsed):
     else:
         description = ''
 
-    appversion.make_application_version(parsed.app_name, version, parsed.dockerrun, parsed.docker_compose, parsed.ebext, description)
+    appversion.make_application_version(parsed.app_name, version, parsed.dockerrun, parsed.docker_compose, parsed.ebext, parsed.ebignore, description)
     logger.info('Ok, now deploying the version %s for %s', version, next_env_name)
     payload = ['eb', 'deploy', next_env_name,
                '--version=' + version]
@@ -132,6 +132,7 @@ def apply_args(parser):
     parser.add_argument('--dockerrun', help='Path to file used as Dockerrun.aws.json')
     parser.add_argument('--docker_compose', help='Path to file used as docker-compose.yml')
     parser.add_argument('--ebext', help='Path to directory used as .ebextensions/')
+    parser.add_argument('--ebignore', help='Path to enignore used as .ebignore')
     parser.add_argument('--exact', help='Prevents Elastic Beanstalk from updating'
                                         'the solution stack version',
                         action='store_true', default=False)

--- a/ebi/commands/create.py
+++ b/ebi/commands/create.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 def main(parsed):
     if parsed.version:
         version = parsed.version
-    elif parsed.prefix :
+    elif parsed.prefix:
         version = "{}_{}".format(parsed.prefix, int(time.time()))
     else:
         version = str(int(time.time()))
@@ -21,7 +21,7 @@ def main(parsed):
     else:
         description = ''
 
-    appversion.make_application_version(parsed.app_name, version, parsed.dockerrun, parsed.docker_compose, parsed.ebext, description)
+    appversion.make_application_version(parsed.app_name, version, parsed.dockerrun, parsed.docker_compose, parsed.ebext, parsed.ebignore, description)
 
     logger.info('Ok, now creating version %s for environment %s', version, parsed.env_name)
     payload = ['eb', 'create', parsed.env_name,
@@ -49,5 +49,6 @@ def apply_args(parser):
     parser.add_argument('--dockerrun', help='Path to file used as Dockerrun.aws.json')
     parser.add_argument('--docker_compose', help='Path to file used as docker-compose.yml')
     parser.add_argument('--ebext', help='Path to directory used as .ebextensions/')
+    parser.add_argument('--ebignore', help='Path to enignore used as .ebignore')
     parser.add_argument('--cfg', help='Configuration template name to eb create')
     parser.set_defaults(func=main)

--- a/ebi/commands/deploy.py
+++ b/ebi/commands/deploy.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 def main(parsed):
     if parsed.version:
         version = parsed.version
-    elif parsed.prefix :
+    elif parsed.prefix:
         version = "{}_{}".format(parsed.prefix, int(time.time()))
     else:
         version = str(int(time.time()))
@@ -21,7 +21,7 @@ def main(parsed):
     else:
         description = ''
 
-    appversion.make_application_version(parsed.app_name, version, parsed.dockerrun, parsed.docker_compose, parsed.ebext, description)
+    appversion.make_application_version(parsed.app_name, version, parsed.dockerrun, parsed.docker_compose, parsed.ebext, parsed.ebignore, description)
     logger.info('Ok, now deploying the version %s for %s', version, parsed.env_name)
     payload = ['eb', 'deploy', parsed.env_name,
                '--version=' + version]
@@ -45,6 +45,7 @@ def apply_args(parser):
     parser.add_argument('--dockerrun', help='Path to file used as Dockerrun.aws.json')
     parser.add_argument('--docker_compose', help='Path to file used as docker-compose.yml')
     parser.add_argument('--ebext', help='Path to directory used as .ebextensions/')
+    parser.add_argument('--ebignore', help='Path to enignore used as .ebignore')
     parser.add_argument('--staged', action='store_true', default=False,
                         help='deploy files staged in git rather than the HEAD commit')
     parser.set_defaults(func=main)

--- a/ebi/copy.py
+++ b/ebi/copy.py
@@ -1,0 +1,11 @@
+import shutil
+
+import igittigitt
+
+
+def copy_eb_files(src, dst, ebignroe_path):
+    """ copy files from src to dst based on ebignore file
+    """
+    parser = igittigitt.IgnoreParser()
+    parser.parse_rule_files("", ebignroe_path)
+    shutil.copytree(src, dst, ignore=parser.shutil_ignore)

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ setup(
     install_requires=[
         'awsebcli>=3.7.3,<4',
         'boto3>=1.2.6,<2',
+        'igittigitt==2.0.4'
     ],
     description='Simple CLI tool for ElasticBeanstalk with Docker',
     long_description=long_description,


### PR DESCRIPTION
## 概要
- ebiではdockerrunとebextention、もしくはdokcer-composeとebextentionのみdeployパッケージに含めている
- 柔軟にdeployするファイルを調整するために、元々`eb`コマンドで使用される`.ebignore`を利用出来るように拡張する
- --ebignoreを指定すると
  - まず、 ebignoreファイルを元にファイルをdeploy用フォルダにコピーする
  - その後、通常通りdockerrunかdokcer-compose、ebextentionを（公式の名称にrenameしつつ）上書きコピーする
- よって、ebignoreにはdockerrun、dokcer-compose、ebextentionについては記載する必要はない（いかなる場合も、その後公式のファイル名でコピーされる）

## 使用するライブラリ
- https://github.com/bitranox/igittigitt MIT
- gitignore形式のファイルを指定すると、そのファイルがignoreされるかされないかを判定する。
- shutil.copytreeの引数ignoreに指定出来る便利関数付き
```py
parser = igittigitt.IgnoreParser()
parser.parse_rule_files("", ebignroe_path)
shutil.copytree(src, dst, ignore=parser.shutil_ignore)
```
>inspired by https://github.com/mherrmann/gitignore_parser but in fact I needed to throw away almost everything, because of serious matching bugs and unmaintainable spaghetti code.

## 代替ライブラリ
- https://github.com/mherrmann/gitignore_parser MIT