### PR TITLE
Deal with deployment based on ebignore

### DIFF
--- a/ebi/appversion.py
+++ b/ebi/appversion.py
@@ -76,13 +76,11 @@ def make_version_file(version_label, dockerrun=None, docker_compose=None, ebext=
 
     * Including :param dockerrun: file as Dockerrun.aws.json
     * Including :param docker-compose: file as dockerrun-compose.yml (for Amazon linux2)
-    * Including :param exext: directory as .ebextensions/
+    * Including :param ebext: directory as .ebextensions/
 
     :return: File path to created zip file (current directory).
     """
     dockerrun = dockerrun or DOCKERRUN_NAME
-    # docker-compose takes precedence over dockerrun
-    docker_settings = docker_compose or dockerrun
 
     ebext = ebext or DOCKEREXT_NAME
 

--- a/ebi/appversion.py
+++ b/ebi/appversion.py
@@ -2,8 +2,10 @@ import logging
 import os
 import shutil
 import tempfile
+import zipfile
 
 import boto3
+from ebcli.core import fileoperations
 from ebcli.lib import s3 as ebs3
 from ebcli.lib import elasticbeanstalk
 from ebcli.objects.exceptions import NotFoundError
@@ -14,6 +16,57 @@ logger = logging.getLogger('ebi')
 DOCKERRUN_NAME = 'Dockerrun.aws.json'
 DOCKER_COMPOSE_NAME = 'docker-compose.yml'
 DOCKEREXT_NAME = '.ebextensions/'
+
+
+def make_version_file_with_ebignore(version_label, dockerrun=None, docker_compose=None, ebext=None):
+    """ Making zip file to upload for ElasticBeanstalk based on ebigore
+
+    :param version_label: will be name of the created zip file
+
+    * Including :param dockerrun: file as Dockerrun.aws.json
+    * Including :param docker-compose: file as dockerrun-compose.yml (for Amazon linux2)
+    * Including :param exext: directory as .ebextensions/
+
+    :return: File path to created zip file (current directory).
+    """
+    dockerrun = dockerrun or DOCKERRUN_NAME
+
+    ebext = ebext or DOCKEREXT_NAME
+
+    tempd = tempfile.mkdtemp()
+    try:
+        ignore_files = fileoperations.get_ebignore_list()
+
+        # Dockerrun, docker-compose and ebextentions files are added to zip file later.
+        ignore_files |= {DOCKERRUN_NAME, DOCKER_COMPOSE_NAME}
+        ignore_ebext_files = set()
+        for file in os.listdir(DOCKEREXT_NAME):
+            ebext_file_path = os.path.join(DOCKEREXT_NAME, file)
+            if os.path.isfile(ebext_file_path):
+                ignore_ebext_files.add(ebext_file_path)
+        ignore_files |= ignore_ebext_files
+
+        zip_filename = version_label + ".zip"
+        temp_zip_path = os.path.join(tempd, zip_filename)
+        fileoperations.zip_up_project(temp_zip_path, ignore_list=ignore_files)
+        shutil.copyfile(temp_zip_path, zip_filename)
+
+        with zipfile.ZipFile(zip_filename, 'a', allowZip64=True) as f:
+            for file in os.listdir(ebext):
+                source_ebext_file_path = os.path.join(ebext, file)
+                target_ebext_file_path = os.path.join(DOCKEREXT_NAME, file)
+                if os.path.isfile(source_ebext_file_path):
+                    f.write(source_ebext_file_path, arcname=target_ebext_file_path)
+
+            if docker_compose:
+                f.write(docker_compose, arcname=DOCKER_COMPOSE_NAME)
+            else:
+                f.write(dockerrun, arcname=DOCKERRUN_NAME)
+
+        return zip_filename
+
+    finally:
+        shutil.rmtree(tempd)
 
 
 def make_version_file(version_label, dockerrun=None, docker_compose=None, ebext=None):
@@ -45,7 +98,7 @@ def make_version_file(version_label, dockerrun=None, docker_compose=None, ebext=
         else:
             deploy_dockerrun = os.path.join(tempd, DOCKERRUN_NAME)
             shutil.copyfile(dockerrun, deploy_dockerrun)
-            
+
         return shutil.make_archive(version_label, 'zip', root_dir=tempd)
     finally:
         shutil.rmtree(tempd)
@@ -68,8 +121,11 @@ def upload_app_version(app_name, bundled_zip):
     return bucket, key
 
 
-def make_application_version(app_name, version, dockerrun, docker_compose, ebext, description):
-    bundled_zip = make_version_file(version, dockerrun=dockerrun, docker_compose=docker_compose, ebext=ebext)
+def make_application_version(app_name, version, dockerrun, docker_compose, ebext, ebignore, description):
+    if ebignore:
+        bundled_zip = make_version_file_with_ebignore(version, dockerrun=dockerrun, docker_compose=docker_compose, ebext=ebext)
+    else:
+        bundled_zip = make_version_file(version, dockerrun=dockerrun, docker_compose=docker_compose, ebext=ebext)
     try:
         bucket, key = upload_app_version(app_name, bundled_zip)
 

--- a/ebi/commands/bgdeploy.py
+++ b/ebi/commands/bgdeploy.py
@@ -110,7 +110,7 @@ def main(parsed):
     ###
     if parsed.version:
         version = parsed.version
-    elif parsed.prefix :
+    elif parsed.prefix:
         version = "{}_{}".format(parsed.prefix, int(time.time()))
     else:
         version = str(int(time.time()))
@@ -120,7 +120,7 @@ def main(parsed):
     else:
         description = ''
 
-    appversion.make_application_version(parsed.app_name, version, parsed.dockerrun, parsed.docker_compose, parsed.ebext, description)
+    appversion.make_application_version(parsed.app_name, version, parsed.dockerrun, parsed.docker_compose, parsed.ebext, parsed.ebignore, description)
     logger.info('Ok, now deploying the version %s for %s', version, secondary_env_name)
     payload = ['eb', 'deploy', secondary_env_name,
                '--version=' + version]
@@ -193,6 +193,8 @@ def apply_args(parser):
     parser.add_argument('--dockerrun', help='Path to file used as Dockerrun.aws.json')
     parser.add_argument('--docker_compose', help='Path to file used as docker-compose.yml')
     parser.add_argument('--ebext', help='Path to directory used as .ebextensions/')
+    parser.add_argument('--ebignore', help='Zip project based on .ebignore',
+                        action='store_true', default=False)
     parser.add_argument('--capacity', help='Set the number of instances.',
                         action='store_true', default=False)
     parser.set_defaults(func=main)

--- a/ebi/commands/clonedeploy.py
+++ b/ebi/commands/clonedeploy.py
@@ -74,7 +74,7 @@ def main(parsed):
     ###
     if parsed.version:
         version = parsed.version
-    elif parsed.prefix :
+    elif parsed.prefix:
         version = "{}_{}".format(parsed.prefix, int(time.time()))
     else:
         version = str(int(time.time()))
@@ -84,7 +84,7 @@ def main(parsed):
     else:
         description = ''
 
-    appversion.make_application_version(parsed.app_name, version, parsed.dockerrun, parsed.docker_compose, parsed.ebext, description)
+    appversion.make_application_version(parsed.app_name, version, parsed.dockerrun, parsed.docker_compose, parsed.ebext, parsed.ebignore, description)
     logger.info('Ok, now deploying the version %s for %s', version, next_env_name)
     payload = ['eb', 'deploy', next_env_name,
                '--version=' + version]
@@ -132,6 +132,8 @@ def apply_args(parser):
     parser.add_argument('--dockerrun', help='Path to file used as Dockerrun.aws.json')
     parser.add_argument('--docker_compose', help='Path to file used as docker-compose.yml')
     parser.add_argument('--ebext', help='Path to directory used as .ebextensions/')
+    parser.add_argument('--ebignore', help='Zip project based on .ebignore',
+                        action='store_true', default=False)
     parser.add_argument('--exact', help='Prevents Elastic Beanstalk from updating'
                                         'the solution stack version',
                         action='store_true', default=False)

--- a/ebi/commands/create.py
+++ b/ebi/commands/create.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 def main(parsed):
     if parsed.version:
         version = parsed.version
-    elif parsed.prefix :
+    elif parsed.prefix:
         version = "{}_{}".format(parsed.prefix, int(time.time()))
     else:
         version = str(int(time.time()))
@@ -21,7 +21,7 @@ def main(parsed):
     else:
         description = ''
 
-    appversion.make_application_version(parsed.app_name, version, parsed.dockerrun, parsed.docker_compose, parsed.ebext, description)
+    appversion.make_application_version(parsed.app_name, version, parsed.dockerrun, parsed.docker_compose, parsed.ebext, parsed.ebignore, description)
 
     logger.info('Ok, now creating version %s for environment %s', version, parsed.env_name)
     payload = ['eb', 'create', parsed.env_name,
@@ -49,5 +49,7 @@ def apply_args(parser):
     parser.add_argument('--dockerrun', help='Path to file used as Dockerrun.aws.json')
     parser.add_argument('--docker_compose', help='Path to file used as docker-compose.yml')
     parser.add_argument('--ebext', help='Path to directory used as .ebextensions/')
+    parser.add_argument('--ebignore', help='Zip project based on .ebignore',
+                        action='store_true', default=False)
     parser.add_argument('--cfg', help='Configuration template name to eb create')
     parser.set_defaults(func=main)

--- a/ebi/commands/deploy.py
+++ b/ebi/commands/deploy.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 def main(parsed):
     if parsed.version:
         version = parsed.version
-    elif parsed.prefix :
+    elif parsed.prefix:
         version = "{}_{}".format(parsed.prefix, int(time.time()))
     else:
         version = str(int(time.time()))
@@ -21,7 +21,7 @@ def main(parsed):
     else:
         description = ''
 
-    appversion.make_application_version(parsed.app_name, version, parsed.dockerrun, parsed.docker_compose, parsed.ebext, description)
+    appversion.make_application_version(parsed.app_name, version, parsed.dockerrun, parsed.docker_compose, parsed.ebext, parsed.ebignore, description)
     logger.info('Ok, now deploying the version %s for %s', version, parsed.env_name)
     payload = ['eb', 'deploy', parsed.env_name,
                '--version=' + version]
@@ -45,6 +45,8 @@ def apply_args(parser):
     parser.add_argument('--dockerrun', help='Path to file used as Dockerrun.aws.json')
     parser.add_argument('--docker_compose', help='Path to file used as docker-compose.yml')
     parser.add_argument('--ebext', help='Path to directory used as .ebextensions/')
+    parser.add_argument('--ebignore', help='Zip project based on .ebignore',
+                        action='store_true', default=False)
     parser.add_argument('--staged', action='store_true', default=False,
                         help='deploy files staged in git rather than the HEAD commit')
     parser.set_defaults(func=main)


### PR DESCRIPTION
## 概要
- ebiではdockerrunとebextention、もしくはdokcer-composeとebextentionのみdeployパッケージに含めている
- 柔軟にdeployするファイルを調整するために、元々`eb`コマンドで使用される`.ebignore`を利用出来るように拡張する
- --ebignoreを指定すると
  - まず、 ebignoreファイルを元にファイルをdeploy用フォルダにコピーする。ただし、Dockerrun.aws.json、docker-compose.yml、.ebextentions/はコピーされない。
  - その後、Dockerrunファイルかdokcer-composeファイル、ebextentionsファイルを（公式の名称にrenameしつつ）上書きコピーする
